### PR TITLE
Add origin to exported ImagePlus

### DIFF
--- a/src/main/java/ch/epfl/biop/bdv/command/exporter/BasicBdvViewToImagePlusExportCommand.java
+++ b/src/main/java/ch/epfl/biop/bdv/command/exporter/BasicBdvViewToImagePlusExportCommand.java
@@ -64,7 +64,7 @@ public class BasicBdvViewToImagePlusExportCommand<T extends RealType<T>> impleme
     private String selected_timepoints_str = "";
 
     @Parameter( label = "Export mode", choices = {"Normal", "Virtual", "Virtual no-cache"}, required = false )
-    private String export_mode = "Non virtual";
+    private String export_mode = "Normal";
 
     //@Parameter( label = "Monitor loaded data")
     private Boolean monitor = true;
@@ -77,6 +77,7 @@ public class BasicBdvViewToImagePlusExportCommand<T extends RealType<T>> impleme
     public ImagePlus imageplus;
 
     double xSize, ySize;
+    private RealPoint ptTopLeft;
 
     @Override
     public void run() {
@@ -121,11 +122,19 @@ public class BasicBdvViewToImagePlusExportCommand<T extends RealType<T>> impleme
                     .rangeT(selected_timepoints_str)
                     .sources(sourceList.toArray(new SourceAndConverter[0]))
                     .get();
+            setOrigin(imageplus);
 
         } catch (Exception e) {
             e.printStackTrace();
         }
 
+    }
+
+    private void setOrigin( ImagePlus imagePlus )
+    {
+        imagePlus.getCalibration().xOrigin = - ptTopLeft.getDoublePosition( 0 ) / samplingxyinphysicalunit;
+        imagePlus.getCalibration().yOrigin = - ptTopLeft.getDoublePosition( 1 ) / samplingxyinphysicalunit;
+        imagePlus.getCalibration().zOrigin = - ptTopLeft.getDoublePosition( 2 ) / samplingzinphysicalunit;
     }
 
     private SourceAndConverter<?> createModelSource() {
@@ -174,8 +183,9 @@ public class BasicBdvViewToImagePlusExportCommand<T extends RealType<T>> impleme
         double h = bdv_h.getViewerPanel().getDisplay().getHeight();
 
         // Get global coordinates of the top left position  of the viewer
-        RealPoint ptTopLeft = new RealPoint(3); // Number of dimension
-        bdv_h.getViewerPanel().displayToGlobalCoordinates(0, 0, ptTopLeft);
+        // Number of dimension
+        ptTopLeft = new RealPoint(3);
+        bdv_h.getViewerPanel().displayToGlobalCoordinates(0, 0, ptTopLeft );
 
         // Get global coordinates of the top right position  of the viewer
         RealPoint ptTopRight = new RealPoint(3); // Number of dimension
@@ -186,8 +196,8 @@ public class BasicBdvViewToImagePlusExportCommand<T extends RealType<T>> impleme
         bdv_h.getViewerPanel().displayToGlobalCoordinates(h,0, ptBottomLeft);
 
         // Gets physical size of pixels based on window size, image sampling size and user requested pixel size
-        this.xSize=BdvViewToImagePlusExportCommand.distance(ptTopLeft, ptTopRight);
-        this.ySize=BdvViewToImagePlusExportCommand.distance(ptTopLeft, ptBottomLeft);
+        this.xSize=BdvViewToImagePlusExportCommand.distance( ptTopLeft, ptTopRight);
+        this.ySize=BdvViewToImagePlusExportCommand.distance( ptTopLeft, ptBottomLeft);
     }
 
 }

--- a/src/test/java/DemoImagePlusExport.java
+++ b/src/test/java/DemoImagePlusExport.java
@@ -1,0 +1,67 @@
+import bdv.tools.brightness.ConverterSetup;
+import bdv.util.BdvHandle;
+import bdv.util.BoundedRealTransform;
+import bdv.viewer.SourceAndConverter;
+import ch.epfl.biop.bdv.command.exporter.BasicBdvViewToImagePlusExportCommand;
+import mpicbg.spim.data.generic.AbstractSpimData;
+import net.imagej.ImageJ;
+import net.imagej.patcher.LegacyInjector;
+import net.imglib2.FinalRealInterval;
+import net.imglib2.type.numeric.ARGBType;
+import sc.fiji.bdvpg.bdv.navigate.ViewerTransformAdjuster;
+import sc.fiji.bdvpg.services.SourceAndConverterServices;
+import sc.fiji.bdvpg.sourceandconverter.display.BrightnessAutoAdjuster;
+import sc.fiji.bdvpg.sourceandconverter.register.BigWarpLauncher;
+import sc.fiji.bdvpg.sourceandconverter.transform.SourceRealTransformer;
+import sc.fiji.bdvpg.spimdata.importer.SpimDataFromXmlImporter;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.stream.Collectors;
+
+public class DemoImagePlusExport
+{
+
+    static {
+        LegacyInjector.preinit();
+    }
+
+    static public void main(String... args) {
+        ImageJ ij = new ImageJ();
+        ij.ui().showUI();
+
+        demo();
+    }
+
+
+    public static void demo() {
+        final String filePath = "src/test/resources/mri-stack.xml";
+        // Import SpimData
+        SpimDataFromXmlImporter importer = new SpimDataFromXmlImporter(filePath);
+
+        AbstractSpimData spimData = importer.get();
+
+        SourceAndConverter sac = SourceAndConverterServices
+                .getSourceAndConverterService()
+                .getSourceAndConverterFromSpimdata(spimData)
+                .get(0);
+
+        // Creates a BdvHandle
+        BdvHandle bdvHandle = SourceAndConverterServices.getBdvDisplayService().getActiveBdv();
+
+        SourceAndConverterServices.getBdvDisplayService().show(bdvHandle, sac);
+
+        new BrightnessAutoAdjuster(sac, 0).run();
+
+        new ViewerTransformAdjuster(bdvHandle, sac).run();
+
+        final BasicBdvViewToImagePlusExportCommand exportCommand = new BasicBdvViewToImagePlusExportCommand();
+        exportCommand.bdv_h = bdvHandle;
+        exportCommand.samplingxyinphysicalunit = 1.0;
+        exportCommand.samplingzinphysicalunit = 1.0;
+        exportCommand.run();
+        exportCommand.imageplus.show();
+
+
+    }
+}


### PR DESCRIPTION
@NicoKiaru 

For one of our projects it is important that we keep track of where we "cropped" the image in BDV that we export. I therefore added code here to add the origin (upper left corner of the BDV window) to the ImagePlus.

If you want we could make this optional by adding a boolean parameter to the Command.

I guess we should then also add the same functionality to the advanced version of the export Command. 

What do you think? (We really need it)

<img width="175" alt="image" src="https://user-images.githubusercontent.com/2157566/134198437-db0af296-70dc-4989-a7df-0f12d80d96aa.png">

<img width="300" alt="image" src="https://user-images.githubusercontent.com/2157566/134198685-64d5e795-f5ff-4b81-8b76-845b7c5f82d2.png">
